### PR TITLE
add trailing slash to BUILD_PATH - fixes build on OS X

### DIFF
--- a/Dockerfile.asterisk-builder
+++ b/Dockerfile.asterisk-builder
@@ -1,7 +1,7 @@
 FROM centos:7
 MAINTAINER Leif Madsen <leif.madsen@avoxi.com>
 ENV PKG_APP yum
-ENV BUILD_PATH /buildrpms
+ENV BUILD_PATH /buildrpms/
 ENV DIST_TAG el7
 
 RUN $PKG_APP clean all


### PR DESCRIPTION
This allows the build to complete using OS X
